### PR TITLE
[タスク][v1.1] 運動データを登録する際のバリデーションチェックの処理を追加する

### DIFF
--- a/lib/config/workOut.dart
+++ b/lib/config/workOut.dart
@@ -1,0 +1,3 @@
+enum WorkOutType {
+  strengthTraining, runOrWalk, other
+}

--- a/lib/view/HealthPage/WorkOutAddPage/model.dart
+++ b/lib/view/HealthPage/WorkOutAddPage/model.dart
@@ -1,0 +1,85 @@
+import 'package:beer_collection/entities/workout.dart';
+
+class RequestWorkOutValidate {
+  bool isInValidWorkOutType = false;
+  bool isInValidRegistryDate = false;
+  bool isInValidCalorie = false;
+  bool isInValidLoad = false;
+  bool isInValidFrequency = false;
+  bool isInValidTime = false;
+  bool isInValidDistance = false;
+
+  void checkInputValue(RequestWorkOut registryWorkOut) {
+    if (registryWorkOut.workOutType == null || registryWorkOut.workOutType == -1) {
+      isInValidWorkOutType = true;
+    } else {
+      isInValidWorkOutType = false;
+    }
+
+    if (registryWorkOut.registryDate.isEmpty) {
+      isInValidRegistryDate = true;
+    } else {
+      isInValidRegistryDate = false;
+    }
+
+    if (registryWorkOut.load == null || registryWorkOut.load == 0.0) {
+      isInValidLoad = true;
+    } else {
+      isInValidLoad = false;
+    }
+
+    if (registryWorkOut.frequency == null || registryWorkOut.frequency == -1) {
+      isInValidFrequency = true;
+    } else {
+      isInValidFrequency = false;
+    }
+
+    if (registryWorkOut.time == null || registryWorkOut.time == -1) {
+      isInValidTime = true;
+    } else {
+      isInValidTime = false;
+    }
+
+    if (registryWorkOut.distance == null || registryWorkOut.distance == 0.0) {
+      isInValidDistance = true;
+    } else {
+      isInValidDistance = false;
+    }
+
+    if (registryWorkOut.calorie < 1) {
+      isInValidCalorie = true;
+    } else {
+      isInValidCalorie = false;
+    }
+  }
+
+  bool isInValidData(int workOutType) {
+    switch(workOutType) {
+      case 0:
+        return (
+          isInValidWorkOutType ||
+          isInValidRegistryDate ||
+          isInValidTime ||
+          isInValidDistance
+        );
+      case 1:
+        return (
+          isInValidWorkOutType ||
+          isInValidRegistryDate ||
+          isInValidLoad ||
+          isInValidFrequency
+        );
+      case 2:
+        return (
+          isInValidWorkOutType ||
+          isInValidRegistryDate
+        );
+      default:
+        return true;
+    }
+  }
+}
+
+void registerWorkOut(RequestWorkOut registryWorkOut) {
+  // データ登録の処理
+}

--- a/lib/view/HealthPage/WorkOutAddPage/work_out_add_page.dart
+++ b/lib/view/HealthPage/WorkOutAddPage/work_out_add_page.dart
@@ -1,5 +1,6 @@
 import 'package:beer_collection/entities/workout.dart';
 import 'package:beer_collection/util/get_week_date.dart';
+import 'package:beer_collection/view/HealthPage/WorkOutAddPage/model.dart';
 import 'package:beer_collection/widgets/common_back_button_widget.dart';
 import 'package:beer_collection/widgets/error_message.dart';
 import 'package:beer_collection/widgets/label_text.dart';
@@ -15,6 +16,7 @@ class WorkOutAddPage extends StatefulWidget {
 
 class _WorkOutAddPageState extends State<WorkOutAddPage> {
   RequestWorkOut registryWorkOut = RequestWorkOut();
+  RequestWorkOutValidate requestWorkOutValidate = RequestWorkOutValidate();
   final TextEditingController _textEditingController = TextEditingController();
 
   List<String> workOutTypeList = ['ランニング・ウォーキング', '筋トレ', 'その他'];
@@ -42,7 +44,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                   _selectDate(context, registryWorkOut);
                 },
               ),
-              const ErrorMessage(errorMessage: '日付が未選択です。日付を選択してください。'),
+              if(requestWorkOutValidate.isInValidRegistryDate) const ErrorMessage(errorMessage: '日付が未選択です。日付を選択してください。'),
               const Gap(16),
               const LabelText( labelText: '運動の内容を選択してください'),
               const Gap(8),
@@ -72,7 +74,10 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                   ),
                 )
               ),
-              const ErrorMessage(errorMessage: '運動の内容が未選択です。運動の内容を選択してください。'),
+              Visibility(
+                visible: requestWorkOutValidate.isInValidWorkOutType,
+                child: const ErrorMessage(errorMessage: '運動の内容が未選択です。運動の内容を選択してください。'),
+              ),            
               const Gap(16),
               Visibility(
                 visible: registryWorkOut.workOutType == 1,
@@ -95,7 +100,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                       });
                     },
                   ),
-                  const ErrorMessage(errorMessage: '負荷の重量が未入力です。負荷の重量を入力してください。'),
+                  if(requestWorkOutValidate.isInValidLoad) const ErrorMessage(errorMessage: '負荷の重量が未入力です。負荷の重量を入力してください。'),
                   const Gap(16),
                   const LabelText( labelText: '回数を入力してください'),
                   TextFormField(
@@ -114,7 +119,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                       });
                     },
                   ),
-                  const ErrorMessage(errorMessage: '回数が未入力です。回数を入力してください。'),
+                  if(requestWorkOutValidate.isInValidFrequency) const ErrorMessage(errorMessage: '回数が未入力です。回数を入力してください。'),
                   ]
                 ),
               ),
@@ -140,7 +145,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                         });
                       },
                     ),
-                    const ErrorMessage(errorMessage: '時間が未入力です。時間を入力してください。'),
+                    if(requestWorkOutValidate.isInValidTime) const ErrorMessage(errorMessage: '時間が未入力です。時間を入力してください。'),
                     const Gap(16),
                     const LabelText( labelText: '移動距離を入力してください'),
                     TextFormField(
@@ -159,7 +164,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                         });
                       },
                     ),
-                    const ErrorMessage(errorMessage: '移動距離が未入力です。移動距離を入力してください。'),
+                    if(requestWorkOutValidate.isInValidDistance) const ErrorMessage(errorMessage: '移動距離が未入力です。移動距離を入力してください。'),
                   ],
                 ),
               ),
@@ -173,6 +178,17 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                     shape: const StadiumBorder()
                   ),
                   onPressed: () {
+                    int currentWorkOutType = registryWorkOut.workOutType ?? -1;
+
+                    setState(() {
+                      requestWorkOutValidate.checkInputValue(registryWorkOut);
+                    });
+
+                    if (requestWorkOutValidate.isInValidData(currentWorkOutType)) {
+                      return;
+                    }
+
+                    registerWorkOut(registryWorkOut);
                     Navigator.of(context).pop();
                   },
                   child: const Text('登録', style: TextStyle(fontSize: 20.0),),

--- a/lib/view/HealthPage/WorkOutAddPage/work_out_add_page.dart
+++ b/lib/view/HealthPage/WorkOutAddPage/work_out_add_page.dart
@@ -1,7 +1,7 @@
-
 import 'package:beer_collection/entities/workout.dart';
 import 'package:beer_collection/util/get_week_date.dart';
 import 'package:beer_collection/widgets/common_back_button_widget.dart';
+import 'package:beer_collection/widgets/error_message.dart';
 import 'package:beer_collection/widgets/label_text.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
@@ -42,6 +42,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                   _selectDate(context, registryWorkOut);
                 },
               ),
+              const ErrorMessage(errorMessage: '日付が未選択です。日付を選択してください。'),
               const Gap(16),
               const LabelText( labelText: '運動の内容を選択してください'),
               const Gap(8),
@@ -71,6 +72,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                   ),
                 )
               ),
+              const ErrorMessage(errorMessage: '運動の内容が未選択です。運動の内容を選択してください。'),
               const Gap(16),
               Visibility(
                 visible: registryWorkOut.workOutType == 1,
@@ -93,6 +95,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                       });
                     },
                   ),
+                  const ErrorMessage(errorMessage: '負荷の重量が未入力です。負荷の重量を入力してください。'),
                   const Gap(16),
                   const LabelText( labelText: '回数を入力してください'),
                   TextFormField(
@@ -111,6 +114,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                       });
                     },
                   ),
+                  const ErrorMessage(errorMessage: '回数が未入力です。回数を入力してください。'),
                   ]
                 ),
               ),
@@ -136,6 +140,7 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                         });
                       },
                     ),
+                    const ErrorMessage(errorMessage: '時間が未入力です。時間を入力してください。'),
                     const Gap(16),
                     const LabelText( labelText: '移動距離を入力してください'),
                     TextFormField(
@@ -154,9 +159,10 @@ class _WorkOutAddPageState extends State<WorkOutAddPage> {
                         });
                       },
                     ),
+                    const ErrorMessage(errorMessage: '移動距離が未入力です。移動距離を入力してください。'),
                   ],
                 ),
-               ),
+              ),
               const Gap(16),
               SizedBox(
                 width: 200, 

--- a/lib/widgets/error_message.dart
+++ b/lib/widgets/error_message.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class ErrorMessage extends StatelessWidget {
+  final String errorMessage;
+
+  const ErrorMessage({Key? key, required this.errorMessage}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Text(
+        errorMessage, 
+        textAlign: TextAlign.left, 
+        style: TextStyle(color: Colors.pink[400], fontSize: 12)
+      ),
+    );
+  }
+}

--- a/test/unit/WorkOutAddPage/checkInputValue_test.dart
+++ b/test/unit/WorkOutAddPage/checkInputValue_test.dart
@@ -1,0 +1,126 @@
+import 'package:beer_collection/entities/workout.dart';
+import 'package:beer_collection/view/HealthPage/WorkOutAddPage/model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('必須項目が入力されているかをチェックするためのメソッドであるcheckInputValueのテスト', () {
+      RequestWorkOutValidate requestWorkOutValidate = RequestWorkOutValidate();
+      RequestWorkOut inputData = RequestWorkOut();
+      inputData.workOutType = 0;
+      inputData.registryDate = '2022/12/13';
+      inputData.load = 12.3;
+      inputData.frequency = 10;
+      inputData.time = 234;
+      inputData.distance = 9.5;
+
+    group('すべての項目が入力されている場合、falseが返ること', () {
+      test('すべての項目が入力されている場合、falseが返ること', () {
+        int currentWorkOutType = inputData.workOutType ?? -1;
+        requestWorkOutValidate.checkInputValue(inputData);
+        expect(requestWorkOutValidate.isInValidData(currentWorkOutType), false);
+      });
+    });
+
+    group('workOutTypeが0(ランニング・ウォーキング)の場合', () {
+      int currentWorkOutType = 0;
+      group('テスト未入力の項目が1つでもある場合にはtrueが返ること', () {
+         test('日付が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.load = 12.3;
+          inputData.frequency = 10;
+          inputData.time = 234;
+          inputData.distance = 9.5;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+
+         test('時間が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.registryDate = '2022/12/13';
+          inputData.load = 12.3;
+          inputData.frequency = 10;
+          inputData.distance = 9.5;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+
+         test('距離が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.registryDate = '2022/12/13';
+          inputData.load = 12.3;
+          inputData.frequency = 10;
+          inputData.time = 234;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+      });
+    });
+
+    group('workOutTypeが1(筋トレ)の場合', () {
+      int currentWorkOutType = 1;
+      group('テスト未入力の項目が1つでもある場合にはtrueが返ること', () {
+        test('日付が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.load = 12.3;
+          inputData.frequency = 10;
+          inputData.time = 234;
+          inputData.distance = 9.5;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+
+         test('重量が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.registryDate = '2022/12/13';
+          inputData.frequency = 10;
+          inputData.time = 234;
+          inputData.distance = 9.5;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+
+         test('回数が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.registryDate = '2022/12/13';
+          inputData.load = 12.3;
+          inputData.time = 234;
+          inputData.distance = 9.5;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+      });
+    });
+
+    group('workOutTypeが2(その他)の場合', () {
+      int currentWorkOutType = 2;
+      group('テスト未入力の項目が1つでもある場合にはtrueが返ること', () {
+        test('日付が空欄の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          inputData.load = 12.3;
+          inputData.frequency = 10;
+          inputData.time = 234;
+          inputData.distance = 9.5;
+          requestWorkOutValidate.checkInputValue(inputData);
+          expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+        });
+      });
+    });
+
+    group('すべての項目が未入力の場合、trueが返ること', () {
+      int currentWorkOutType = -1;
+      test('すべての項目が未入力の場合、trueが返ること', () {
+          RequestWorkOut inputData = RequestWorkOut();
+          inputData.workOutType = currentWorkOutType;
+          requestWorkOutValidate.checkInputValue(inputData);
+        expect(requestWorkOutValidate.isInValidData(currentWorkOutType), true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
### 確認事項
* 共通
   * 日付が未入力で登録ボタンをクリックした場合、エラーとなること
   * 運動内容が未入力で登録ボタンをクリックした場合、エラーとなること
* 筋トレ
   * 負荷の重量が未入力で登録ボタンをクリックした場合、エラーとなること
   * 回数が未入力で登録ボタンをクリックした場合、エラーとなること
   * 回数に整数以外の値を入力し、登録ボタンをクリックした場合、エラーとなること
* ランニング・ウォーキング
   * 時間が未入力で登録ボタンをクリックした場合、エラーとなること
   * 移動距離が未入力で登録ボタンをクリックした場合、エラーとなること
   * 移動距離に数字以外の値を入力し、登録ボタンをクリックした場合、エラーとなること