### PR TITLE
[タスク] [v1.1] GitHub ActionsによるGoogle Play Consoleへのアプリ自動アップロードを実装する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: flutter CI
+name: flutter CI/CD
 
 on:
   push:
@@ -9,25 +9,44 @@ on:
       - '**.md'
 
 jobs:
-  build:
+  build-android:
     runs-on: ubuntu-latest
 
     steps:
       - name: チェックアウト
         uses: actions/checkout@v3
-      
       # https://github.com/subosito/flutter-action
       - name: CIジョブを動かすためのflutterの環境構築
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.0.2'
+          flutter-version: '3.7.7'
           channel: 'stable'
-
+      - name: CIジョブを動かすためのJavaの環境構築
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
       - name: 正常にインストールできているかを確認
         run: flutter --version
-
       - name: パッケージのインストール
         run: flutter pub get
+      - name: Androidの成果物をビルド
+        run: flutter build apk
+      - run: flutter build appbundle
 
-      - name: テスト実行
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.7.7'
+          channel: 'stable'
+      - run: flutter pub get
+      - run: flutter build ios --release --no-codesign
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: テストを実行
         run: flutter test 


### PR DESCRIPTION
#91

### 目的
* GitHub ActionsによるGoogle Play Consoleへのアプリ自動アップロード機能を実装し、作業を省力化する

### 参考
* [GitHub ActionsによるGoogle Play Consoleへのアプリ自動アップロードの取り組み](https://techblog.zozo.com/entry/google-play-upload)
* [GitHub ActionsによるGoogle Play Consoleへのアプリ自動アップロード ZOZO](https://speakerdeck.com/takenaga7/github-actionswoshi-yong-sitegoogle-play-consolenizi-dong-atupurodo)
* [【Flutter】GitHub Actions で Android 向けに自動デプロイする](https://zenn.dev/pressedkonbu/articles/github-actions-for-android)

### 確認事項
* Google Play Consoleへのアプリ自動アップロードできる機構を実装できていること
* v1.1リリースの際に使用できること